### PR TITLE
Potential fix for code scanning alert no. 78: Information exposure through a stack trace

### DIFF
--- a/src/plugins/command-control/cc.js
+++ b/src/plugins/command-control/cc.js
@@ -188,7 +188,7 @@ export class CommandControl {
       this.log.e(rxid, "err cc:op", e.stack);
       response = pres.errResponse("cc:op", e);
       // TODO: set response status to 5xx
-      response.data.httpResponse = jsonResponse(e.stack);
+      response.data.httpResponse = jsonResponse({ error: "An internal error occurred" });
     }
 
     return response;


### PR DESCRIPTION
Potential fix for [https://github.com/KS-OTO/serverless-dns/security/code-scanning/78](https://github.com/KS-OTO/serverless-dns/security/code-scanning/78)

To fix the issue, the stack trace (`e.stack`) should be removed from the user-facing response. Instead, a generic error message should be sent to the user, while the stack trace is logged on the server for debugging purposes. This ensures that sensitive information is not exposed to the user while retaining the ability to debug issues internally.

The changes involve:
1. Logging the stack trace (`e.stack`) using the existing logging mechanism (`this.log.e`).
2. Replacing `jsonResponse(e.stack)` with a generic error message such as `jsonResponse({ error: "An internal error occurred" })`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
